### PR TITLE
Add RetroArch Snap

### DIFF
--- a/apps/games/retroarch/metadata.json
+++ b/apps/games/retroarch/metadata.json
@@ -22,7 +22,7 @@
         "zesty",
         "artful"
     ],
-    "methods": ["apt"],
+    "methods": ["apt", "snap"],
     "apt": {
         "default": {
             "main-package": "retroarch",
@@ -37,6 +37,6 @@
         }
     },
     "snap": {
-		"name": null
-	}
+        "name": "retroarch"
+    }
 }

--- a/tests/validate-metadata.py
+++ b/tests/validate-metadata.py
@@ -119,6 +119,7 @@ for category in categories:
                 index["apt"]["default"]
 
             if "snap" in index["methods"]:
+                i = index["snap"]
                 i["name"]
 
         except Exception as reason:


### PR DESCRIPTION
This change adds the [snap for RetroArch](https://snapcraft.io/retroarch).